### PR TITLE
✨ Feature: 모집중인 / 참여중인 띱 더보기, 띱 상세보기 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "prepare": "husky",
+    "prepare": "husky || true",
     "icons": "npx @svgr/cli --out-dir src/components/icons -- public/assets/images"
   },
   "dependencies": {
@@ -29,6 +29,7 @@
     "react-hook-form": "^7.51.0",
     "react-router-dom": "^6.22.3",
     "tailwind-merge": "^2.2.2",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.22.4",
     "zustand": "^4.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ dependencies:
   tailwind-merge:
     specifier: ^2.2.2
     version: 2.2.2
+  tailwind-scrollbar-hide:
+    specifier: ^1.1.7
+    version: 1.1.7
   tailwindcss-animate:
     specifier: ^1.0.7
     version: 1.0.7(tailwindcss@3.4.1)
@@ -4766,6 +4769,10 @@ packages:
     resolution: {integrity: sha512-tWANXsnmJzgw6mQ07nE3aCDkCK4QdT3ThPMCzawoYA2Pws7vSTCvz3Vrjg61jVUGfFZPJzxEP+NimbcW+EdaDw==}
     dependencies:
       '@babel/runtime': 7.24.0
+    dev: false
+
+  /tailwind-scrollbar-hide@1.1.7:
+    resolution: {integrity: sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA==}
     dev: false
 
   /tailwindcss-animate@1.0.7(tailwindcss@3.4.1):

--- a/public/assets/images/commentButtonIcon.svg
+++ b/public/assets/images/commentButtonIcon.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="14" viewBox="0 0 16 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_306_333)">
+<path d="M0 14L15.9924 7L0 0V5.44444L11.421 7L0 8.55556V14Z" fill="#2388FF"/>
+</g>
+<defs>
+<clipPath id="clip0_306_333">
+<rect width="16" height="14" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/Home/RecruitingCarousel.tsx
+++ b/src/components/Home/RecruitingCarousel.tsx
@@ -7,8 +7,10 @@ import {
 import { Card, CardContent } from '@/components/ui/card.tsx';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
+import { useNavigate } from 'react-router-dom';
 
 const RecruitingCarousel = () => {
+  const navigate = useNavigate();
   return (
     <Carousel className={'w-full max-w-sm'}>
       <CarouselContent className={'w-full mx-auto'}>
@@ -38,7 +40,8 @@ const RecruitingCarousel = () => {
                   <div
                     className={
                       'text-[8px] text-hc-grayDark cursor-pointer underline'
-                    }>
+                    }
+                    onClick={() => navigate('/ddeep/123')}>
                     상세보기
                   </div>
                 </div>

--- a/src/components/Home/SectionHeader.tsx
+++ b/src/components/Home/SectionHeader.tsx
@@ -1,17 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+
 interface SectionHeaderProps {
   title: string;
   hasMoreDetails?: boolean;
+  showMorePath?: string;
 }
 
 const SectionHeader = ({
   title,
-  hasMoreDetails = false
+  hasMoreDetails = false,
+  showMorePath
 }: SectionHeaderProps) => {
+  const navigate = useNavigate();
+
   return (
     <div className={'p-4 flex justify-between items-center'}>
       <div className={'text-[18px] font-bold text-hc-black'}>{title}</div>
-      {hasMoreDetails && (
-        <div className={'text-[12px] text-hc-grayDark cursor-pointer'}>
+      {hasMoreDetails && showMorePath && (
+        <div
+          className={'text-[12px] text-hc-grayDark cursor-pointer'}
+          onClick={() => navigate(showMorePath)}>
           {'더보기 >'}
         </div>
       )}

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,14 +1,17 @@
 import React, { ComponentPropsWithoutRef, ForwardedRef } from 'react';
 import { cn } from '@/lib/utils.ts';
+import CommentButtonIcon from '@/components/icons/CommentButtonIcon.tsx';
 
 interface InputProps extends ComponentPropsWithoutRef<'input'> {
   variant: 'gray' | 'white';
   error?: boolean;
+  className?: string;
+  hasCommentButton?: boolean;
 }
 
 const Input = React.forwardRef(
   (
-    { variant, error, ...otherProps }: InputProps,
+    { variant, error, className, hasCommentButton, ...otherProps }: InputProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {
     const inputVariant = {
@@ -17,15 +20,24 @@ const Input = React.forwardRef(
     };
 
     return (
-      <input
-        className={cn(
-          'w-[338px] h-[54px] rounded-3xl border-2 border-hc-grayLight focus:outline-none text-sm font-semibold px-6 py-2.5 mt-5',
-
-          inputVariant[variant]
+      <div className={'flex justify-center items-center relative'}>
+        <input
+          className={cn(
+            'w-[338px] h-[54px] rounded-3xl border-2 border-hc-grayLight focus:outline-none text-sm font-semibold px-6 py-2.5 mt-5',
+            inputVariant[variant],
+            className
+          )}
+          {...otherProps}
+          ref={ref}
+        />
+        {hasCommentButton && (
+          <CommentButtonIcon
+            width={16}
+            height={14}
+            className={'absolute top-1/2 right-4 cursor-pointer'}
+          />
         )}
-        {...otherProps}
-        ref={ref}
-      />
+      </div>
     );
   }
 );

--- a/src/components/icons/CommentButtonIcon.tsx
+++ b/src/components/icons/CommentButtonIcon.tsx
@@ -1,0 +1,26 @@
+import { SVGProps } from 'react';
+
+const SvgCommentButtonIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={'current'}
+    height={'current'}
+    fill="none"
+    {...props}>
+    <g clipPath="url(#commentButtonIcon_svg__a)">
+      <path
+        fill="#2388FF"
+        d="m0 14 15.992-7L0 0v5.444L11.421 7 0 8.556z"
+      />
+    </g>
+    <defs>
+      <clipPath id="commentButtonIcon_svg__a">
+        <path
+          fill="#fff"
+          d="M0 0h16v14H0z"
+        />
+      </clipPath>
+    </defs>
+  </svg>
+);
+export default SvgCommentButtonIcon;

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -1,4 +1,7 @@
-export { default as CirclePlusIcon } from './CirclePlusIcon.js';
-export { default as HomeIcon } from './HomeIcon.js';
-export { default as MessageIcon } from './MessageIcon.js';
-export { default as UserIcon } from './UserIcon.js';
+export { default as CirclePlusIcon } from './CirclePlusIcon';
+export { default as CommentButtonIcon } from './CommentButtonIcon.js';
+export { default as HcLogoLabel } from './HcLogoLabel';
+export { default as HcLogoPic } from './HcLogoPic';
+export { default as HomeIcon } from './HomeIcon';
+export { default as MessageIcon } from './MessageIcon';
+export { default as UserIcon } from './UserIcon';

--- a/src/pages/Ddeep/DdeepDetail.tsx
+++ b/src/pages/Ddeep/DdeepDetail.tsx
@@ -66,7 +66,9 @@ const DdeepDetail = () => {
         </CardContent>
       </Card>
       <div className={'w-full flex justify-start mt-2 ml-8 items-center'}>
-        <div className={'text-[14px] text-hc-blue-darker'}>댓글 (1)</div>
+        <div className={'text-[14px] font-semibold text-hc-blue-darker'}>
+          댓글 (1)
+        </div>
       </div>
       <Input
         variant={'gray'}

--- a/src/pages/Ddeep/DdeepDetail.tsx
+++ b/src/pages/Ddeep/DdeepDetail.tsx
@@ -1,5 +1,100 @@
+import { useParams } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card.tsx';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import Input from '@/components/common/Input.tsx';
+import { EllipsisVerticalIcon } from 'lucide-react';
+
 const DdeepDetail = () => {
-  return <div>DdeepDetail</div>;
+  const { id } = useParams<{ id: string }>();
+  return (
+    <div className={'w-full flex flex-col items-center'}>
+      <Card
+        className={
+          'border-none bg-hc-grayLighter w-[358px] h-[200px] rounded-2xl mt-5'
+        }>
+        <CardContent className={'flex flex-col gap-y-2.5 px-3.5'}>
+          <div className={'w-full mt-3 flex'}>
+            <Badge
+              className={
+                'w-14 h-6 bg-hc-blue-dark text-hc-white text-[12px] flex justify-center'
+              }>
+              {/* TODO: 대체 필요 */}
+              전시회
+            </Badge>
+          </div>
+          <div className={'w-full flex justify-between'}>
+            <div className={'text-[16px] font-bold text-hc-black'}>
+              띱! 같이 전시회 가실 분 구합니다!
+            </div>
+          </div>
+          <div className={'flex flex-col gap-y-1'}>
+            <div className={'flex gap-x-1'}>
+              {/* TODO: 대체 필요*/}
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                이름 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                김헤쳐
+              </div>
+            </div>
+            <div className={'flex gap-x-1'}>
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                인원 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                4명/5명
+              </div>
+            </div>
+            <div className={'flex gap-x-1'}>
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                설명 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                전시회 가서 예쁜 그림도 보고 사진도 찍어요~
+              </div>
+            </div>
+          </div>
+          <div className={'w-full flex justify-end mt-1'}>
+            <Button
+              className={
+                'w-[75px] h-[30px] bg-hc-blue-300 text-hc-white text-[12px] rounded-[12px]'
+              }>
+              나가기
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+      <div className={'w-full flex justify-start mt-2 ml-8 items-center'}>
+        <div className={'text-[14px] text-hc-blue-darker'}>댓글 (1)</div>
+      </div>
+      <Input
+        variant={'gray'}
+        className={
+          'w-[358px] h-[43px] bg-hc-grayLighter border-hc-grayLighter mt-3'
+        }
+        placeholder={'댓글을 입력하세요'}
+        hasCommentButton
+      />
+      <div
+        className={
+          'w-[358px] h-[73px] flex flex-col rounded-2xl bg-hc-grayLighter mt-3'
+        }>
+        <div className={'px-6 pt-3.5 flex justify-between items-center'}>
+          <div className={'flex items-end'}>
+            <div className={'font-bold text-[16px] text-hc-black'}>김밥</div>
+            <div className={'text-[10px] text-hc-grayDark ml-2'}>2시간 전</div>
+          </div>
+          <div className={'text-[10px] text-hc-grayDark ml-2 cursor-pointer'}>
+            <EllipsisVerticalIcon size={14} />
+          </div>
+        </div>
+        <div className={'px-6 pt-1 text-[12px] text-hc-black'}>
+          오 일정은 언제일까요?
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default DdeepDetail;

--- a/src/pages/Ddeep/DdeepMoreParticipating.tsx
+++ b/src/pages/Ddeep/DdeepMoreParticipating.tsx
@@ -1,0 +1,71 @@
+import { Card, CardContent } from '@/components/ui/card.tsx';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button.tsx';
+
+const DdeepMoreParticipating = () => {
+  return (
+    <div className={'w-full flex flex-col justify-center items-center'}>
+      <div className={'px-3.5 pt-4 w-full flex justify-start items-center'}>
+        <h1 className={'text-[18px] font-bold'}>참여중인 띱!</h1>
+      </div>
+      <Card
+        className={
+          'bg-hc-white border-hc-blue border-2 w-[358px] h-[158px] rounded-3xl mt-3'
+        }>
+        <CardContent className={'flex flex-col gap-y-1 px-3.5'}>
+          <div className={'w-full mt-3 flex'}>
+            <Badge
+              className={
+                'w-12 h-5 bg-hc-blue-dark text-hc-white text-[10px] flex justify-center'
+              }>
+              {/* TODO: 대체 필요 */}
+              전시회
+            </Badge>
+          </div>
+          <div className={'w-full flex justify-between'}>
+            <div className={'text-[16px] font-bold text-hc-black'}>
+              띱! 같이 전시회 가실 분 구합니다!
+            </div>
+          </div>
+          <div className={'flex flex-col'}>
+            <div className={'flex gap-x-1'}>
+              {/* TODO: 대체 필요*/}
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                이름 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                김헤쳐
+              </div>
+            </div>
+            <div className={'flex gap-x-1'}>
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                인원 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                4명/5명
+              </div>
+            </div>
+            <div className={'flex gap-x-1'}>
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                설명 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                전시회 가서 예쁜 그림도 보고 사진도 찍어요~
+              </div>
+            </div>
+          </div>
+          <div className={'w-full flex justify-end'}>
+            <Button
+              className={
+                'w-[70px] h-[28px] bg-hc-blue-300 text-hc-white text-[12px] rounded-[12px] -mt-1'
+              }>
+              나가기
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DdeepMoreParticipating;

--- a/src/pages/Ddeep/DdeepMoreRecruiting.tsx
+++ b/src/pages/Ddeep/DdeepMoreRecruiting.tsx
@@ -1,0 +1,71 @@
+import { Card, CardContent } from '@/components/ui/card.tsx';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button.tsx';
+
+const DdeepMoreRecruiting = () => {
+  return (
+    <div className={'w-full flex flex-col justify-center items-center'}>
+      <div className={'px-3.5 pt-4 w-full flex justify-start items-center'}>
+        <h1 className={'text-[18px] font-bold'}>다함께 띱!</h1>
+      </div>
+      <Card
+        className={
+          'bg-hc-white border-hc-blue border-2 w-[358px] h-[158px] rounded-3xl mt-3'
+        }>
+        <CardContent className={'flex flex-col gap-y-1 px-3.5'}>
+          <div className={'w-full mt-3 flex'}>
+            <Badge
+              className={
+                'w-12 h-5 bg-hc-blue-dark text-hc-white text-[10px] flex justify-center'
+              }>
+              {/* TODO: 대체 필요 */}
+              전시회
+            </Badge>
+          </div>
+          <div className={'w-full flex justify-between'}>
+            <div className={'text-[16px] font-bold text-hc-black'}>
+              띱! 같이 전시회 가실 분 구합니다!
+            </div>
+          </div>
+          <div className={'flex flex-col'}>
+            <div className={'flex gap-x-1'}>
+              {/* TODO: 대체 필요*/}
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                이름 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                김헤쳐
+              </div>
+            </div>
+            <div className={'flex gap-x-1'}>
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                인원 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                4명/5명
+              </div>
+            </div>
+            <div className={'flex gap-x-1'}>
+              <div className={'text-[12px] font-semibold text-hc-blue-dark'}>
+                설명 |
+              </div>
+              <div className={'text-[12px] font-semibold text-hc-black'}>
+                전시회 가서 예쁜 그림도 보고 사진도 찍어요~
+              </div>
+            </div>
+          </div>
+          <div className={'w-full flex justify-end'}>
+            <Button
+              className={
+                'w-[70px] h-[28px] bg-hc-blue-300 text-hc-white text-[12px] rounded-[12px] -mt-1'
+              }>
+              참여하기
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DdeepMoreRecruiting;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -11,6 +11,7 @@ const Home = () => {
         <SectionHeader
           title={'모집중인 띱'}
           hasMoreDetails={true}
+          showMorePath={'/ddeep/more/recruiting'}
         />
         <RecruitingCarousel />
       </section>
@@ -18,6 +19,7 @@ const Home = () => {
         <SectionHeader
           title={'참여중인 띱'}
           hasMoreDetails={true}
+          showMorePath={'/ddeep/more/participating'}
         />
         <ParticipatingCarousel />
       </section>

--- a/src/routes/HFLayout.tsx
+++ b/src/routes/HFLayout.tsx
@@ -20,7 +20,7 @@ const HFLayout = ({ headerVariant, backPath, headerTitle }: HFLayoutProps) => {
       ) : (
         <Header />
       )}
-      <main className={'h-[calc(100dvh-118px)]'}>
+      <main className={'h-[calc(100dvh-118px)] overflow-scroll scrollbar-hide'}>
         <Outlet />
       </main>
       <Footer />

--- a/src/routes/HLayout.tsx
+++ b/src/routes/HLayout.tsx
@@ -1,10 +1,24 @@
 import { Outlet } from 'react-router-dom';
 import Header from '@/components/common/Header.tsx';
 
-const HLayout = () => {
+interface HLayoutProps {
+  headerVariant?: 'default' | 'back';
+  backPath?: string;
+  headerTitle?: string;
+}
+
+const HLayout = ({ headerVariant, backPath, headerTitle }: HLayoutProps) => {
   return (
     <div className={'w-[390px] h-dvh mx-auto border-2 border-hc-blue-light'}>
-      <Header />
+      {headerVariant === 'back' ? (
+        <Header
+          variant={'back'}
+          backPath={backPath}
+          headerTitle={headerTitle}
+        />
+      ) : (
+        <Header />
+      )}
       <main>
         <Outlet />
       </main>

--- a/src/routes/HLayout.tsx
+++ b/src/routes/HLayout.tsx
@@ -19,7 +19,7 @@ const HLayout = ({ headerVariant, backPath, headerTitle }: HLayoutProps) => {
       ) : (
         <Header />
       )}
-      <main>
+      <main className={'h-[calc(100dvh-53px)] overflow-scroll scrollbar-hide'}>
         <Outlet />
       </main>
     </div>

--- a/src/routes/PageRouter.tsx
+++ b/src/routes/PageRouter.tsx
@@ -59,7 +59,14 @@ const PageRouter = () => {
           element={<MyPage />}
         />
       </Route>
-      <Route element={<HLayout />}>
+      <Route
+        element={
+          <HLayout
+            headerVariant={'back'}
+            backPath={'/'}
+            headerTitle={'모집중인 띱'}
+          />
+        }>
         <Route
           path={'/ddeep/:id'}
           element={<DdeepDetail />}

--- a/src/routes/PageRouter.tsx
+++ b/src/routes/PageRouter.tsx
@@ -7,6 +7,8 @@ import DdeepCreate from '@/pages/Ddeep/DdeepCreate.tsx';
 import DdeepDetail from '@/pages/Ddeep/DdeepDetail.tsx';
 import Message from '@/pages/Message';
 import MyPage from '@/pages/MyPage';
+import DdeepMoreParticipating from '@/pages/Ddeep/DdeepMoreParticipating.tsx';
+import DdeepMoreRecruiting from '@/pages/Ddeep/DdeepMoreRecruiting.tsx';
 
 const PageRouter = () => {
   return (
@@ -61,6 +63,32 @@ const PageRouter = () => {
         <Route
           path={'/ddeep/:id'}
           element={<DdeepDetail />}
+        />
+      </Route>
+      <Route
+        element={
+          <HLayout
+            headerVariant={'back'}
+            headerTitle={'참여중인 띱'}
+            backPath={'/'}
+          />
+        }>
+        <Route
+          path={'/ddeep/more/participating'}
+          element={<DdeepMoreParticipating />}
+        />
+      </Route>
+      <Route
+        element={
+          <HLayout
+            headerVariant={'back'}
+            headerTitle={'모집중인 띱'}
+            backPath={'/'}
+          />
+        }>
+        <Route
+          path={'/ddeep/more/recruiting'}
+          element={<DdeepMoreRecruiting />}
         />
       </Route>
       <Route

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,5 +50,5 @@ module.exports = {
       }
     }
   },
-  plugins: [require('tailwindcss-animate')]
+  plugins: [require('tailwindcss-animate'), require('tailwind-scrollbar-hide')]
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,7 @@ module.exports = {
       'hc-blue-darker': '#003CD2',
       'hc-white': '#FFFFFF',
       'hc-black': '#000000',
+      'hc-grayLighter': '#F5F6F8',
       'hc-grayLight': '#EEEEEE',
       'hc-gray': '#D9D9D9',
       'hc-grayDark': '#585858',


### PR DESCRIPTION
## 🪄 작업 내용 또는 변경 사항
- [x] 모집중인 띱 더보기 페이지의 외형을 구현했습니다.
- [x] 참여중인 띱 더보기 페이지의 외형을 구현했습니다.
- [x] 띱 상세보기 페이지의 외형을 구현했습니다.

## 🎨결과 화면
<img width="385" alt="스크린샷 2024-03-23 오후 7 23 07" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_18_FE/assets/69716992/b04771ab-cff2-4e33-89cf-033ce7943dce">
<img width="383" alt="스크린샷 2024-03-23 오후 7 23 21" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_18_FE/assets/69716992/450f1f3e-2550-422e-9f8c-6ea0e349005d">
<img width="385" alt="스크린샷 2024-03-23 오후 7 24 31" src="https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_18_FE/assets/69716992/6c008b5b-2834-43c9-a500-0f3819f49313">



## 💬 리뷰어에게 전할 말
카드 컴포넌트가 코드 상으로 중복되는게 많아서, 추후 공통 컴포넌트로 분리하겠습니다!

## ⭐️ 관련 이슈
close #10